### PR TITLE
Musepack updates

### DIFF
--- a/src/libmpcdec/mpc_decoder.c
+++ b/src/libmpcdec/mpc_decoder.c
@@ -59,6 +59,10 @@ extern const mpc_can_data mpc_can_Q [8][2];
 extern const mpc_can_data mpc_can_Q1;
 extern const mpc_can_data mpc_can_Q9up;
 
+extern const mpc_uint8_t       Res_bit[18];
+extern const MPC_SAMPLE_FORMAT __Cc[1 + 18];
+extern const mpc_int16_t       __Dc[1 + 18];
+
 //------------------------------------------------------------------------------
 // types
 //------------------------------------------------------------------------------
@@ -105,7 +109,7 @@ void mpc_decoder_set_streaminfo(mpc_decoder *d, mpc_streaminfo *si)
 	d->ms                 = si->ms;
 	d->max_band           = si->max_band;
 	d->channels           = si->channels;
-	d->samples_to_skip    = MPC_DECODER_SYNTH_DELAY + si->beg_silence;
+	d->samples_to_skip    = MPC_DECODER_SYNTH_DELAY + (mpc_uint32_t)si->beg_silence;
 
 	if (si->stream_version == 7 && si->is_true_gapless)
 		d->samples = ((si->samples + MPC_FRAME_LENGTH - 1) / MPC_FRAME_LENGTH) * MPC_FRAME_LENGTH;

--- a/src/libmpcdec/mpc_reader.c
+++ b/src/libmpcdec/mpc_reader.c
@@ -67,7 +67,7 @@ tell_stdio(mpc_reader *p_reader)
 {
     mpc_reader_stdio *p_stdio = (mpc_reader_stdio*) p_reader->data;
     if(p_stdio->magic != STDIO_MAGIC) return MPC_STATUS_FAIL;
-    return ftell(p_stdio->p_file);
+    return (mpc_int32_t)ftell(p_stdio->p_file);
 }
 
 static mpc_int32_t
@@ -89,7 +89,9 @@ canseek_stdio(mpc_reader *p_reader)
 mpc_status
 mpc_reader_init_stdio_stream(mpc_reader * p_reader, FILE * p_file)
 {
-    mpc_reader tmp_reader; mpc_reader_stdio *p_stdio; int err;
+    mpc_reader tmp_reader;
+    mpc_reader_stdio *p_stdio;
+    long err;
 
     p_stdio = NULL;
     memset(&tmp_reader, 0, sizeof tmp_reader);
@@ -104,7 +106,7 @@ mpc_reader_init_stdio_stream(mpc_reader * p_reader, FILE * p_file)
     if(err < 0) goto clean;
     err = ftell(p_stdio->p_file);
     if(err < 0) goto clean;
-    p_stdio->file_size = err;
+    p_stdio->file_size = (int)err;
     err = fseek(p_stdio->p_file, 0, SEEK_SET);
     if(err < 0) goto clean;
 

--- a/src/libmpcdec/mpcdec.h
+++ b/src/libmpcdec/mpcdec.h
@@ -46,11 +46,10 @@
 extern "C" {
 #endif
 
-enum {
-    MPC_FRAME_LENGTH          = (36 * 32),              ///< Samples per mpc frame
-    MPC_DECODER_BUFFER_LENGTH = (MPC_FRAME_LENGTH * 4), ///< Required buffer size for decoder
-    MPC_DECODER_SYNTH_DELAY   = 481
-};
+
+#define MPC_FRAME_LENGTH (36 * 32)
+#define MPC_DECODER_BUFFER_LENGTH (MPC_FRAME_LENGTH * 4)
+#define MPC_DECODER_SYNTH_DELAY 481
 
 typedef struct mpc_decoder_t mpc_decoder;
 typedef struct mpc_demux_t mpc_demux;

--- a/src/libmpcdec/requant.h
+++ b/src/libmpcdec/requant.h
@@ -47,9 +47,11 @@ extern "C" {
 
 
 /* C O N S T A N T S */
-const mpc_uint8_t      Res_bit [18];     ///< Bits per sample for chosen quantizer
+/*
+const mpc_uint8_t      Res_bit [18];      ///< Bits per sample for chosen quantizer
 const MPC_SAMPLE_FORMAT __Cc    [1 + 18]; ///< Requantization coefficients
 const mpc_int16_t       __Dc    [1 + 18]; ///< Requantization offset
+*/
 
 #define Cc (__Cc + 1)
 #define Dc (__Dc + 1)


### PR DESCRIPTION
I've made some fixes to ensure the libmusepack code compiles under clang on OS X and finished wiring up the decoder object's framelist generation.  It seems to decode a couple of test files correctly which is a good sign.

I should be able to build Python-level Musepack objects tomorrow, get it to pass the unit tests (hopefully) and fold it back into the main branch.