### PR TITLE
Python-level Musepack support

### DIFF
--- a/audiotools/__init__.py
+++ b/audiotools/__init__.py
@@ -1753,6 +1753,8 @@ def file_type(file):
             return None
     elif header[0:4] == b"TTA1":
         return TrueAudio
+    elif header[0:4] == b"MPCK":
+        return MPCAudio
     else:
         return None
 
@@ -5753,6 +5755,7 @@ from audiotools.m4a import M4AAudio
 from audiotools.m4a import ALACAudio
 from audiotools.opus import OpusAudio
 from audiotools.tta import TrueAudio
+from audiotools.mpc import MPCAudio
 
 from audiotools.ape import ApeTag
 from audiotools.flac import FlacMetaData
@@ -5775,7 +5778,8 @@ AVAILABLE_TYPES = (FlacAudio,
                    ALACAudio,
                    WavPackAudio,
                    OpusAudio,
-                   TrueAudio)
+                   TrueAudio,
+                   MPCAudio)
 
 TYPE_MAP = {track_type.NAME: track_type for track_type in AVAILABLE_TYPES}
 

--- a/audiotools/mpc.py
+++ b/audiotools/mpc.py
@@ -1,11 +1,47 @@
 from audiotools import (AudioFile, InvalidFile)
+from audiotools.ape import ApeTaggedAudio
+from audiotools.bitstream import BitstreamReader, BitstreamWriter
+
+
+class MPC_Size:
+    def __init__(self, value, length):
+        self.__value__ = value
+        self.__length__ = length
+
+    def __repr__(self):
+        return "MPC_Size(%d, %d)" % (self.__value__, self.__length__)
+
+    def __int__(self):
+        return self.__value__
+
+    def __len__(self):
+        return self.__length__
+
+    @classmethod
+    def parse(cls, reader):
+        cont, value = reader.parse("1u 7u")
+        length = 1
+
+        while cont == 1:
+            cont, value2 = reader.parse("1u 7u")
+            value = (value << 7) | value2
+            length += 1
+
+        return cls(value, length)
+
+    def build(self, writer):
+        for i in reversed(range(self.__length__)):
+            writer.write(1, 1 if (i > 0) else 0)
+            writer.write(7, (self.__value__ >> (i * 7)) & 0x7F)
+
 
 class InvalidMPC(InvalidFile):
     """raised by invalid files during MPC initialization"""
 
     pass
 
-class MPCAudio(AudioFile):
+
+class MPCAudio(ApeTaggedAudio, AudioFile):
     """an MPC audio file"""
 
     SUFFIX = "mpc"
@@ -26,5 +62,199 @@ class MPCAudio(AudioFile):
                                 "7": u"excellent quality (~240 kbps)",
                                 "8": u"excellent quality (~270 kbps)",
                                 "9": u"excellent quality (~300 kbps)",
-                                "10": u"excellent quality (~350 kbps)"} 
+                                "10": u"excellent quality (~350 kbps)"}
 
+    def __init__(self, filename):
+        """filename is a plain string"""
+
+        AudioFile.__init__(self, filename)
+        block = BitstreamReader(self.get_block(b"SH"), False)
+        crc = block.read(32)
+        if block.read(8) != 8:
+            from audiotools.text import ERR_MPC_INVALID_VERSION
+            raise InvalidMPC(ERR_MPC_INVALID_VERSION)
+        self.__samples__ = int(MPC_Size.parse(block))
+        beg_silence = int(MPC_Size.parse(block))
+        self.__sample_rate__ = \
+            [44100, 4800, 37800, 3200][block.read(3)]
+        max_band = block.read(5) + 1
+        self.__channels__ = block.read(4) + 1
+        ms = block.read(1)
+        block_pwr = block.read(3) * 2
+
+    def blocks(self):
+        with BitstreamReader(open(self.filename, "rb"), False) as r:
+            if r.read_bytes(4) != b"MPCK":
+                raise InvalidMPC(ERR_MPC_INVALID_ID)
+
+            try:
+                while True:
+                    key = r.read_bytes(2)
+                    size = MPC_Size.parse(r)
+                    yield key, size, r.read_bytes(int(size) - len(size) - 2)
+            except IOError:
+                return
+
+    def get_block(self, block_id):
+        for key, size, block in self.blocks():
+            if key == block_id:
+                return block
+        else:
+            raise KeyError(block_id)
+
+    def bits_per_sample(self):
+        """returns an integer number of bits-per-sample this track contains"""
+
+        return 16
+
+    def channels(self):
+        """returns an integer number of channels this track contains"""
+
+        return self.__channels__
+
+    def lossless(self):
+        """returns True if this track's data is stored losslessly"""
+
+        return False
+
+    def total_frames(self):
+        """returns the total PCM frames of the track as an integer"""
+
+        return self.__samples__
+
+    def sample_rate(self):
+        """returns the rate of the track's audio as an integer number of Hz"""
+
+        return self.__sample_rate__
+
+    @classmethod
+    def supports_to_pcm(cls):
+        """returns True if all necessary components are available
+        to support the .to_pcm() method"""
+
+        try:
+            from audiotools.decoders import MPCDecoder
+            return True
+        except ImportError:
+            return False
+
+    def to_pcm(self):
+        """returns a PCMReader object containing the track's PCM data
+
+        if an error occurs initializing a decoder, this should
+        return a PCMReaderError with an appropriate error message"""
+
+        from audiotools.decoders import MPCDecoder
+
+        try:
+            return MPCDecoder(self.filename)
+        except (IOError, ValueError) as err:
+            from audiotools import PCMReaderError
+            return PCMReaderError(error_message=str(err),
+                                  sample_rate=self.sample_rate(),
+                                  channels=self.channels(),
+                                  channel_mask=int(self.channel_mask()),
+                                  bits_per_sample=self.bits_per_sample())
+
+    @classmethod
+    def supports_from_pcm(cls):
+        """returns True if all necessary components are available
+        to support the .from_pcm() classmethod"""
+
+        # FIXME - update this once encoder is implemented
+        return False
+
+    @classmethod
+    def supports_replay_gain(cls):
+        """returns True if this class supports ReplayGain"""
+
+        return True
+
+    def get_replay_gain(self):
+        """returns a ReplayGain object of our ReplayGain values
+
+        returns None if we have no values
+
+        may raise IOError if unable to read the file"""
+
+        from audiotools import ReplayGain
+
+        try:
+            rg = BitstreamReader(self.get_block(b"RG"), False)
+        except KeyError:
+            return None
+
+        version = rg.read(8)
+        if version != 1:
+            return None
+
+        gain_title = rg.read(16)
+        peak_title = rg.read(16)
+        gain_album = rg.read(16)
+        peak_album = rg.read(16)
+
+        if ((gain_title == 0) and (peak_title == 0) and
+            (gain_album == 0) and (peak_album == 0)):
+            return None
+        else:
+            return ReplayGain(
+                track_gain=64.82 - float(gain_title) / 256,
+                track_peak=(10 ** (float(peak_title) / 256 / 20)) / 2 ** 15,
+                album_gain=64.82 - float(gain_album) / 256,
+                album_peak=(10 ** (float(peak_album) / 256 / 20)) / 2 ** 15)
+
+    def set_replay_gain(self, replaygain):
+        """given a ReplayGain object, sets the track's gain to those values
+
+        may raise IOError if unable to modify the file"""
+
+        from math import log10
+        from audiotools import TemporaryFile
+
+        gain_title = int(round((64.82 - replaygain.track_gain) * 256))
+        peak_title = int(log10(replaygain.track_peak * 2 ** 15) * 20 * 256)
+        gain_album = int(round((64.82 - replaygain.album_gain) * 256))
+        peak_album = int(log10(replaygain.album_peak * 2 ** 15) * 20 * 256)
+
+        #FIXME - check for missing "RG" block and add one if not present
+
+        writer = BitstreamWriter(TemporaryFile(self.filename), False)
+        writer.write_bytes(b"MPCK")
+        for key, size, block in self.blocks():
+            if key != b"RG":
+                writer.write_bytes(key)
+                size.build(writer)
+                writer.write_bytes(block)
+            else:
+                writer.write_bytes(b"RG")
+                MPC_Size(2 + 1 + 1 + 2 * 4, 1).build(writer)
+                writer.write(8, 1)
+                writer.write(16, gain_title)
+                writer.write(16, peak_title)
+                writer.write(16, gain_album)
+                writer.write(16, peak_album)
+        writer.close()
+
+    def delete_replay_gain(self):
+        """removes ReplayGain values from file, if any
+
+        may raise IOError if unable to modify the file"""
+
+        from audiotools import TemporaryFile
+
+        writer = BitstreamWriter(TemporaryFile(self.filename), False)
+        writer.write_bytes(b"MPCK")
+        for key, size, block in self.blocks():
+            if key != b"RG":
+                writer.write_bytes(key)
+                size.build(writer)
+                writer.write_bytes(block)
+            else:
+                writer.write_bytes(b"RG")
+                MPC_Size(2 + 1 + 1 + 2 * 4, 1).build(writer)
+                writer.write(8, 1)
+                writer.write(16, 0)
+                writer.write(16, 0)
+                writer.write(16, 0)
+                writer.write(16, 0)
+        writer.close()

--- a/audiotools/text.py
+++ b/audiotools/text.py
@@ -641,6 +641,8 @@ ERR_WAVPACK_INVALID_HEADER = u"WavPack header ID invalid"
 ERR_WAVPACK_UNSUPPORTED_FMT = u"unsupported FMT compression"
 ERR_WAVPACK_INVALID_FMT = u"invalid FMT chunk"
 ERR_WAVPACK_NO_FMT = u"FMT chunk not found in WavPack"
+ERR_MPC_INVALID_ID = u"invalid Musepack stream ID"
+ERR_MPC_INVALID_VERSION = u"invalid Musepack version"
 ERR_NO_COMPRESSION_MODES = u"Audio type \"%s\" has no quality modes"
 ERR_UNSUPPORTED_COMPRESSION_MODE = \
     u"\"%(quality)s\" is not a supported compression mode " + \


### PR DESCRIPTION
I've added basic Python-level Musepack support for format detection, decoding, APEv2 tagging, and support for its built-in ReplayGain block.  Seeking is a lower priority because it's currently only used for CD image handling and that's generally reserved for lossless codecs; MP3, Vorbis and Opus decoders don't have seek() methods yet either, for instance.  Though if stream splicing allows a Musepack file to be split/joined without re-encoding, that might be useful.